### PR TITLE
Reintroduce replacement of system and environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ mvn clean install
 ```
 
 ## Testing the plugin
-* If you'd like to run the plugin's tests, install the plugin and run the following command:
+* If you'd like to run the plugin's tests, run the following commands:
 ```
+mvn clean install
 mvn verify -DskipITs=false
 ```
 The above command run both unit and integration tests.
 
 * In order to remote debug the integration tests, add `debugITs=true` property to the test command and add a break point in your IDE:
 ```
+mvn clean install
 mvn verify -DskipITs=false -DdebugITs=true
 ```
 After running the above command, you should start a remote debugging session on port 5005 and wait until the code reaches the break point.

--- a/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
+++ b/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
@@ -17,6 +17,7 @@ import org.jfrog.build.extractor.clientConfiguration.ClientProperties;
 import org.jfrog.buildinfo.deployment.BuildInfoRecorder;
 import org.jfrog.buildinfo.resolution.RepositoryListener;
 import org.jfrog.buildinfo.resolution.ResolutionRepoHelper;
+import org.jfrog.buildinfo.utils.Utils;
 
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -62,8 +63,17 @@ public class ArtifactoryMojo extends AbstractMojo {
 
     @Override
     public void execute() {
+        replaceVariables();
         enforceResolution();
         enforceDeployment();
+    }
+
+    /**
+     * Replace variables in pom.xml surrounded by {{}} with environment and system variables.
+     */
+    private void replaceVariables() {
+        artifactory.delegate.getAllProperties().replaceAll((key, value) -> Utils.parseInput(value));
+        deployProperties.replaceAll((key, value) -> Utils.parseInput(value));
     }
 
     /**
@@ -97,19 +107,19 @@ public class ArtifactoryMojo extends AbstractMojo {
     }
 
     /**
-     * Skip the default maven deploy behaviour.
-     */
-    private void skipDefaultDeploy() {
-        session.getUserProperties().put("maven.deploy.skip", Boolean.TRUE.toString());
-    }
-
-    /**
      * Return true if 'deploy' or 'maven-deploy-plugin' goals exist.
      *
      * @return true if 'deploy' or 'maven-deploy-plugin' goals exist
      */
     private boolean deployGoalExist() {
         return session.getGoals().stream().anyMatch(goal -> ArrayUtils.contains(DEPLOY_GOALS, goal));
+    }
+
+    /**
+     * Skip the default maven deploy behaviour.
+     */
+    private void skipDefaultDeploy() {
+        session.getUserProperties().put("maven.deploy.skip", Boolean.TRUE.toString());
     }
 
     /**
@@ -151,7 +161,7 @@ public class ArtifactoryMojo extends AbstractMojo {
      * Add a single deploy property.
      *
      * @param deployProperties - The deploy properties collection
-     * @param key              - The ket of the property
+     * @param key              - The key of the property
      * @param value            - The value of the property
      */
     private void addDeployProperty(Properties deployProperties, String key, String value) {

--- a/src/main/java/org/jfrog/buildinfo/utils/Utils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/Utils.java
@@ -157,7 +157,7 @@ public class Utils {
      * Parse "aaa{{var1|var2|var3}bbb}" values provided by the user in the pom.xml.
      *
      * @param input - Value from pom.xml
-     * @return - The selected value
+     * @return the selected value
      * @throws IllegalArgumentException if '}}' is missing
      */
     public static String parseInput(String input) {
@@ -185,7 +185,7 @@ public class Utils {
      * or system properties. Last variable is the fallback (default) value if wrapped in double quotes.
      *
      * @param input - Input values surrounded by {{}}, separated by "|"
-     * @return First variable exist in environment or system properties. Empty string otherwise.
+     * @return first variable exist in environment or system properties. Empty string otherwise.
      * @throws IllegalArgumentException if '}}' is missing
      */
     private static String parseCurlyBrackets(String input) {
@@ -211,10 +211,10 @@ public class Utils {
         // Otherwise, return empty string.
         int lastNotDefault = defaultValue == null ? tokens.length - 1 : tokens.length - 2;
         for (int i = 0; i <= lastNotDefault; i++) {
-            String val = tokens[i];
-            String res = StringUtils.firstNonBlank(System.getenv(val), System.getProperty(val));
-            if (res != null) {
-                return res;
+            String currentToken = tokens[i];
+            String variableValue = StringUtils.firstNonBlank(System.getenv(currentToken), System.getProperty(currentToken));
+            if (variableValue != null) {
+                return variableValue;
             }
         }
 

--- a/src/main/java/org/jfrog/buildinfo/utils/Utils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/Utils.java
@@ -1,6 +1,7 @@
 package org.jfrog.buildinfo.utils;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.Maven;
 import org.apache.maven.plugin.logging.Log;
@@ -150,5 +151,73 @@ public class Utils {
      */
     public static boolean isFile(File file) {
         return file != null && file.isFile();
+    }
+
+    /**
+     * Parse "aaa{{var1|var2|var3}bbb}" values provided by the user in the pom.xml.
+     *
+     * @param input - Value from pom.xml
+     * @return - The selected value
+     * @throws IllegalArgumentException if '}}' is missing
+     */
+    public static String parseInput(String input) {
+        StringBuilder result = new StringBuilder();
+        while (StringUtils.isNotBlank(input)) {
+            // Add everything before '{{' to results
+            String beforeBrackets = StringUtils.substringBefore(input, "{{");
+            result.append(beforeBrackets);
+
+            // Remove everything before '{{'
+            input = StringUtils.removeStart(input, beforeBrackets);
+
+            // Parse everything inside '{{}}'
+            if (StringUtils.startsWith(input, "{{")) {
+                result.append(parseCurlyBrackets(input));
+                // Remove '{{}}'
+                input = StringUtils.substringAfter(input, "}}");
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Parse "{{var1|var2|var3}}" entries in the value specified to their corresponding environment variables
+     * or system properties. Last variable is the fallback (default) value if wrapped in double quotes.
+     *
+     * @param input - Input values surrounded by {{}}, separated by "|"
+     * @return First variable exist in environment or system properties. Empty string otherwise.
+     * @throws IllegalArgumentException if '}}' is missing
+     */
+    private static String parseCurlyBrackets(String input) {
+        // Unbox curly brackets from string
+        String unboxed = StringUtils.substringBetween(input, "{{", "}}");
+        if (unboxed == null) {
+            throw new IllegalArgumentException("Illegal input '" + input + "'. Missing '}}'.");
+        }
+
+        // Tokenize string by '|'
+        String[] tokens = StringUtils.split(unboxed, "|");
+        if (ArrayUtils.isEmpty(tokens)) {
+            // {{}}
+            return StringUtils.EMPTY;
+        }
+
+        // Calculate default value
+        String lastValue = tokens[tokens.length - 1];
+        String defaultValue = StringUtils.substringBetween(lastValue, "\""); // Nullable
+
+        // Return first value that exists as environment variable or system property.
+        // Otherwise, if the default value exist, return it.
+        // Otherwise, return empty string.
+        int lastNotDefault = defaultValue == null ? tokens.length - 1 : tokens.length - 2;
+        for (int i = 0; i <= lastNotDefault; i++) {
+            String val = tokens[i];
+            String res = StringUtils.firstNonBlank(System.getenv(val), System.getProperty(val));
+            if (res != null) {
+                return res;
+            }
+        }
+
+        return StringUtils.defaultString(defaultValue);
     }
 }

--- a/src/test/java/org/jfrog/buildinfo/ArtifactoryMojoTest.java
+++ b/src/test/java/org/jfrog/buildinfo/ArtifactoryMojoTest.java
@@ -17,6 +17,12 @@ import static org.jfrog.build.extractor.clientConfiguration.ClientProperties.PRO
  */
 public class ArtifactoryMojoTest extends ArtifactoryMojoTestBase {
 
+    @Override
+    public void setUp() throws Exception {
+        System.setProperty("USER_FROM_SYS_PROP", "admin");
+        super.setUp();
+    }
+
     public void testArtifactoryConfiguration() {
         Config.Artifactory configArtifactory = mojo.artifactory;
         assertNotNull(configArtifactory);
@@ -68,8 +74,9 @@ public class ArtifactoryMojoTest extends ArtifactoryMojoTestBase {
         // Test input deploy properties
         Map<String, String> deployProperties = mojo.deployProperties;
         assertNotNull(deployProperties);
-        assertEquals(1, deployProperties.size());
+        assertEquals(2, deployProperties.size());
         assertEquals("propVal", deployProperties.get("propKey"));
+        assertEquals(System.getenv("JAVA_HOME"), deployProperties.get("javaHome"));
 
         // Test actual deploy properties
         Config.Artifactory configArtifactory = mojo.artifactory;
@@ -80,6 +87,7 @@ public class ArtifactoryMojoTest extends ArtifactoryMojoTestBase {
         assertEquals("buildName", deployProperties.get(PROP_DEPLOY_PARAM_PROP_PREFIX + BuildInfoFields.BUILD_NAME));
         assertEquals("1", deployProperties.get(PROP_DEPLOY_PARAM_PROP_PREFIX + BuildInfoFields.BUILD_NUMBER));
         assertEquals("propVal", deployProperties.get(PROP_DEPLOY_PARAM_PROP_PREFIX + "propKey"));
+        assertEquals(System.getenv("JAVA_HOME"), deployProperties.get(PROP_DEPLOY_PARAM_PROP_PREFIX + "javaHome"));
     }
 
     public void testResolutionRepositories() {

--- a/src/test/java/org/jfrog/buildinfo/utils/parseInput/ConstantsTests.java
+++ b/src/test/java/org/jfrog/buildinfo/utils/parseInput/ConstantsTests.java
@@ -1,0 +1,81 @@
+package org.jfrog.buildinfo.utils.parseInput;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.jfrog.buildinfo.utils.Utils.parseInput;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ */
+@RunWith(Parameterized.class)
+public class ConstantsTests {
+
+    @Parameterized.Parameters(name = "{index}: parseInput({0})={1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"{{}}", ""},
+                {"{{abc}}", ""},
+                {"{{abc|def}}", ""},
+                {"{{A|B|C|def}}", ""},
+                {"{{\"\"}}", ""},
+                {"{{}}{{\"\"}}", ""},
+                {"{{\"\"}}{{}}", ""},
+                {"{{\"abc\"}}", "abc"},
+                {"{{\"abc|\"def\"}}", "def"},
+                {"{{\"abc\"}}def{{\"\"}}", "abcdef"},
+                {"{{\"abc\"}}def{{\"zzz\"}}", "abcdefzzz"},
+                {"{{\"abc\"}}def{{\"zzz|uuu\"}}", "abcdef"},
+                {"{{\"abc|xxx\"}}def{{\"zzz|uuu\"}}", "def"},
+                {"{{A|B|C|\"def\"}}", "def"},
+                {"{{A|B}}_{{D|E}}", "_"},
+                {"{{A|B}}_{{D|E|\"f\"}}", "_f"},
+                {"{{A|B|\"c\"}}_{{D|E}}", "c_"},
+                {"{{A|B|\"c\"}}_{{D|E|\"ee\"}}", "c_ee"},
+                {"{{JAVA_HOME2|EDITOR2}}", ""},
+                {"{{JAVA_HOME2|EDITOR2|\"a\"}}", "a"},
+                {"{{A|EDITOR2|B|\"aa\"}}", "aa"},
+                {"aa{{}}bb", "aabb"},
+                {"aa{{\"\"}}", "aa"},
+                {"aa{{\"abc\"}}", "aaabc"},
+                {"aa{{abc}}", "aa"},
+                {"aa{{\"abc|def\"}}", "aa"},
+                {"aa{{\"abc|\"def\"}}", "aadef"},
+                {"aa{{abc|\"def\"}}", "aadef"},
+                {"aa{{}}{{\"\"}}", "aa"},
+                {"aa{{\"\"}}{{}}", "aa"},
+                {"aa{{\"abc\"}}def{{\"\"}}", "aaabcdef"},
+                {"aa{{\"abc\"}}def{{\"\"}}{{qqq}}", "aaabcdef"},
+                {"aa{{\"abc\"}}def{{\"zzz\"}}", "aaabcdefzzz"},
+                {"aa{{\"abc\"}}def{{\"zzz|uuu\"}}", "aaabcdef"},
+                {"aa{{\"abc|xxx\"}}def{{\"zzz|uuu\"}}", "aadef"},
+                {"aa{{A|B|C|\"def\"}}", "aadef"},
+                {"aa{{A|B|C|def}}", "aa"},
+                {"aa{{A|B}}_{{D|E}}", "aa_"},
+                {"aa{{A|B}}_{{D|E|\"f\"}}", "aa_f"},
+                {"aa{{A|B|\"c\"}}_{{D|E}}", "aac_"},
+                {"aa{{A|B|\"c\"}}_{{D|E|\"ee\"}}", "aac_ee"},
+                {"aa{{JAVA_HOME2|EDITOR2}}", "aa"},
+                {"aa{{JAVA_HOME2|EDITOR2|\"\"}}", "aa"},
+                {"aa{{JAVA_HOME2|EDITOR2|\"x\"}}", "aax"},
+                {"aa{{A|EDITOR2|B|\"rr\"}}", "aarr"},
+                {"aa{{A|C|B|\"rr\"}}z{ff}{{d}}", "aarrz{ff}"}
+        });
+    }
+
+    @Parameterized.Parameter
+    public String expression;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Test
+    public void testParseInput() {
+        assertEquals(expected, parseInput(expression));
+    }
+}

--- a/src/test/java/org/jfrog/buildinfo/utils/parseInput/EnvironmentVariableTests.java
+++ b/src/test/java/org/jfrog/buildinfo/utils/parseInput/EnvironmentVariableTests.java
@@ -1,0 +1,43 @@
+package org.jfrog.buildinfo.utils.parseInput;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.jfrog.buildinfo.utils.Utils.parseInput;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ */
+@RunWith(Parameterized.class)
+public class EnvironmentVariableTests {
+
+    @Parameterized.Parameters(name = "{index}: parseInput({0})={1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"{{JAVA_HOME}}", "JAVA_HOME"},
+                {"{{A|JAVA_HOME|B}}", "JAVA_HOME"},
+                {"{{JAVA_HOME|JAVA_HOME}}", "JAVA_HOME"},
+                {"{{AAA|JAVA_HOME}}", "JAVA_HOME"},
+                {"{{JAVA_HOME|BBB}}", "JAVA_HOME"},
+                {"{{JAVA_HOME}}|{{JAVA_HOME}}", "JAVA_HOME|JAVA_HOME"}
+        });
+    }
+
+    @Parameterized.Parameter
+    public String expression;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Test
+    public void testParseInput() {
+        expected = Arrays.stream(expected.split("\\|")).map(System::getenv).collect(Collectors.joining("|"));
+        assertEquals(expected, parseInput(expression));
+    }
+}

--- a/src/test/java/org/jfrog/buildinfo/utils/parseInput/ExceptionTests.java
+++ b/src/test/java/org/jfrog/buildinfo/utils/parseInput/ExceptionTests.java
@@ -1,0 +1,37 @@
+package org.jfrog.buildinfo.utils.parseInput;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.jfrog.buildinfo.utils.Utils.parseInput;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * @author yahavi
+ */
+@RunWith(Parameterized.class)
+public class ExceptionTests {
+
+    @Parameterized.Parameters(name = "{index}: parseInput({0})")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"{{"},
+                {"abc{{"},
+                {"abc{{def"},
+                {"abc{{def{{"},
+                {"abc{{def{{ghi"}
+        });
+    }
+
+    @Parameterized.Parameter
+    public String expression;
+
+    @Test
+    public void testParseInput() {
+        assertThrows(IllegalArgumentException.class, () -> parseInput(expression));
+    }
+}

--- a/src/test/java/org/jfrog/buildinfo/utils/parseInput/SystemPropertyTests.java
+++ b/src/test/java/org/jfrog/buildinfo/utils/parseInput/SystemPropertyTests.java
@@ -1,0 +1,49 @@
+package org.jfrog.buildinfo.utils.parseInput;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.jfrog.buildinfo.utils.Utils.parseInput;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ */
+@RunWith(Parameterized.class)
+public class SystemPropertyTests {
+
+    @BeforeClass
+    public static void setUp() {
+        System.setProperty("SOME_PROP", "SOME_VAL");
+    }
+
+    @Parameterized.Parameters(name = "{index}: parseInput({0})={1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"{{SOME_PROP}}", "SOME_PROP"},
+                {"{{A|SOME_PROP|B}}", "SOME_PROP"},
+                {"{{SOME_PROP|SOME_PROP}}", "SOME_PROP"},
+                {"{{AAA|SOME_PROP}}", "SOME_PROP"},
+                {"{{SOME_PROP|BBB}}", "SOME_PROP"},
+                {"{{SOME_PROP}}|{{SOME_PROP}}", "SOME_PROP|SOME_PROP"}
+        });
+    }
+
+    @Parameterized.Parameter
+    public String expression;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Test
+    public void testParseInput() {
+        expected = Arrays.stream(expected.split("\\|")).map(System::getProperty).collect(Collectors.joining("|"));
+        assertEquals(expected, parseInput(expression));
+    }
+}

--- a/src/test/resources/unit-tests-pom/pom.xml
+++ b/src/test/resources/unit-tests-pom/pom.xml
@@ -25,6 +25,7 @@
                         <configuration>
                             <deployProperties>
                                 <propKey>propVal</propKey>
+                                <javaHome>{{JAVA_HOME}}</javaHome>
                             </deployProperties>
                             <artifactory>
                                 <includeEnvVars>true</includeEnvVars>
@@ -35,15 +36,15 @@
                             </artifactory>
                             <resolver>
                                 <contextUrl>http://1.2.3.4/artifactory</contextUrl>
-                                <username>admin</username>
-                                <password>password</password>
+                                <username>{{USER_FROM_SYS_PROP}}</username>
+                                <password>{{READ|THE|DEFAULT|=>|"password"}}</password>
                                 <repoKey>libs-release</repoKey>
                                 <downloadSnapshotRepoKey>libs-snapshot</downloadSnapshotRepoKey>
                             </resolver>
                             <publisher>
                                 <contextUrl>http://1.2.3.4/artifactory</contextUrl>
-                                <username>admin</username>
-                                <password>password</password>
+                                <username>{{NOT_EXIST|USER_FROM_SYS_PROP}}</username>
+                                <password>pa{{EMPTY}}ss{{WORD|"word"}}</password>
                                 <excludePatterns>*-tests.jar</excludePatterns>
                                 <repoKey>libs-release-local</repoKey>
                                 <snapshotRepoKey>libs-snapshot-local</snapshotRepoKey>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

Reintroduce expression syntax algorithm of environment and system variables that had been removed in 3.0.0.
Usage example:

```xml
<publisher>
    <contextUrl>{{ARTIFACTORY_CONTEXT_URL|"https://oss.jfrog.org"}}</contextUrl>
    ...
</publisher>
<buildInfo>
    <buildNumber>{{DRONE_BUILD_NUMBER|TRAVIS_BUILD_NUMBER|CI_BUILD_NUMBER|BUILD_NUMBER|"333"}}</buildNumber>
    <buildUrl>{{DRONE_BUILD_URL|CI_BUILD_URL|BUILD_URL}}</buildUrl>
</buildInfo>
```