### PR TITLE
Allow plugin to be inherited

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
+++ b/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
@@ -62,8 +62,10 @@ public class ArtifactoryMojo extends AbstractMojo {
 
     @Override
     public void execute() {
-        enforceResolution();
-        enforceDeployment();
+        if (session.getRequest().getData().putIfAbsent("configured", Boolean.TRUE) == null) {
+            enforceResolution();
+            enforceDeployment();
+        }
     }
 
     /**
@@ -91,7 +93,7 @@ public class ArtifactoryMojo extends AbstractMojo {
         skipDefaultDeploy();
         completeConfig();
         addDeployProperties();
-        BuildInfoRecorder executionListener = new BuildInfoRecorder(session, getLog(), artifactory.delegate);
+        BuildInfoRecorder executionListener = new BuildInfoRecorder(session, getLog(), artifactory.delegate, session.getRequest().getExecutionListener());
         repositoryListener.setBuildInfoRecorder(executionListener);
         session.getRequest().setExecutionListener(executionListener);
     }

--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
@@ -7,6 +7,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.execution.AbstractExecutionListener;
 import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
@@ -48,12 +49,14 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     private final ArtifactoryClientConfiguration conf;
     private final BuildDeployer buildDeployer;
     private final Log logger;
+    private final ExecutionListener wrappedListener;
 
-    public BuildInfoRecorder(MavenSession session, Log logger, ArtifactoryClientConfiguration conf) {
+    public BuildInfoRecorder(MavenSession session, Log logger, ArtifactoryClientConfiguration conf, ExecutionListener wrappedListener) {
         this.buildInfoBuilder = new BuildInfoModelPropertyResolver(logger, session, conf);
         this.buildDeployer = new BuildDeployer(logger);
         this.logger = logger;
         this.conf = conf;
+        this.wrappedListener = wrappedListener;
     }
 
     /**
@@ -84,6 +87,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         currentModuleArtifacts.remove();
         currentModuleDependencies.remove();
         buildTimeDependencies.clear();
+
+        if (wrappedListener != null) {
+            wrappedListener.projectSucceeded(event);
+        }
     }
 
     /**
@@ -94,6 +101,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     @Override
     public void mojoSucceeded(ExecutionEvent event) {
         addDependencies(event.getProject());
+
+        if (wrappedListener != null) {
+            wrappedListener.mojoSucceeded(event);
+        }
     }
 
     /**
@@ -104,6 +115,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     @Override
     public void mojoFailed(ExecutionEvent event) {
         addDependencies(event.getProject());
+
+        if (wrappedListener != null) {
+            wrappedListener.mojoFailed(event);
+        }
     }
 
     /**
@@ -118,6 +133,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             buildDeployer.deploy(build, conf, deployableArtifacts);
         }
         deployableArtifacts.clear();
+
+        if (wrappedListener != null) {
+            wrappedListener.sessionEnded(event);
+        }
     }
 
     /**
@@ -379,5 +398,97 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             return snapshotsRepository;
         }
         return conf.publisher.getRepoKey();
+    }
+
+    // Forward any all events to the wrapped listener if set
+    @Override
+    public void projectDiscoveryStarted(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.projectDiscoveryStarted(event);
+        }
+    }
+
+    @Override
+    public void sessionStarted(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.sessionStarted(event);
+        }
+    }
+
+    @Override
+    public void projectSkipped(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.projectSkipped(event);
+        }
+    }
+
+    @Override
+    public void projectStarted(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.projectStarted(event);
+        }
+    }
+
+    @Override
+    public void projectFailed(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.projectFailed(event);
+        }
+    }
+
+    @Override
+    public void forkStarted(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.forkStarted(event);
+        }
+    }
+
+    @Override
+    public void forkSucceeded(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.forkSucceeded(event);
+        }
+    }
+
+    @Override
+    public void forkFailed(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.forkFailed(event);
+        }
+    }
+
+    @Override
+    public void mojoSkipped(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.mojoSkipped(event);
+        }
+    }
+
+    @Override
+    public void mojoStarted(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.mojoStarted(event);
+        }
+    }
+
+    @Override
+    public void forkedProjectStarted(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.forkedProjectStarted(event);
+        }
+    }
+
+    @Override
+    public void forkedProjectSucceeded(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.forkedProjectSucceeded(event);
+        }
+    }
+
+    @Override
+    public void forkedProjectFailed(ExecutionEvent event) {
+        if (wrappedListener != null) {
+            wrappedListener.forkedProjectFailed(event);
+        }
     }
 }

--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
@@ -3,6 +3,7 @@ package org.jfrog.buildinfo.deployment;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.execution.AbstractExecutionListener;
@@ -38,7 +39,7 @@ import static org.jfrog.buildinfo.utils.Utils.*;
 /**
  * @author yahavi
  */
-public class BuildInfoRecorder extends AbstractExecutionListener implements BuildInfoExtractor<ExecutionEvent> {
+public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, ExecutionListener {
 
     private final Map<String, DeployDetails> deployableArtifacts = Maps.newConcurrentMap();
     private final Set<Artifact> buildTimeDependencies = Collections.synchronizedSet(new HashSet<>());
@@ -56,7 +57,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         this.buildDeployer = new BuildDeployer(logger);
         this.logger = logger;
         this.conf = conf;
-        this.wrappedListener = wrappedListener;
+        this.wrappedListener = ObjectUtils.defaultIfNull(wrappedListener, new AbstractExecutionListener());
     }
 
     /**
@@ -88,9 +89,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         currentModuleDependencies.remove();
         buildTimeDependencies.clear();
 
-        if (wrappedListener != null) {
-            wrappedListener.projectSucceeded(event);
-        }
+        wrappedListener.projectSucceeded(event);
     }
 
     /**
@@ -102,9 +101,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     public void mojoSucceeded(ExecutionEvent event) {
         addDependencies(event.getProject());
 
-        if (wrappedListener != null) {
-            wrappedListener.mojoSucceeded(event);
-        }
+        wrappedListener.mojoSucceeded(event);
     }
 
     /**
@@ -116,9 +113,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     public void mojoFailed(ExecutionEvent event) {
         addDependencies(event.getProject());
 
-        if (wrappedListener != null) {
-            wrappedListener.mojoFailed(event);
-        }
+        wrappedListener.mojoFailed(event);
     }
 
     /**
@@ -134,9 +129,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         }
         deployableArtifacts.clear();
 
-        if (wrappedListener != null) {
-            wrappedListener.sessionEnded(event);
-        }
+        wrappedListener.sessionEnded(event);
     }
 
     /**
@@ -403,92 +396,66 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     // Forward any all events to the wrapped listener if set
     @Override
     public void projectDiscoveryStarted(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.projectDiscoveryStarted(event);
-        }
+        wrappedListener.projectDiscoveryStarted(event);
     }
 
     @Override
     public void sessionStarted(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.sessionStarted(event);
-        }
+        wrappedListener.sessionStarted(event);
     }
 
     @Override
     public void projectSkipped(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.projectSkipped(event);
-        }
+        wrappedListener.projectSkipped(event);
     }
 
     @Override
     public void projectStarted(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.projectStarted(event);
-        }
+        wrappedListener.projectStarted(event);
     }
 
     @Override
     public void projectFailed(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.projectFailed(event);
-        }
+        wrappedListener.projectFailed(event);
     }
 
     @Override
     public void forkStarted(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.forkStarted(event);
-        }
+        wrappedListener.forkStarted(event);
     }
 
     @Override
     public void forkSucceeded(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.forkSucceeded(event);
-        }
+        wrappedListener.forkSucceeded(event);
     }
 
     @Override
     public void forkFailed(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.forkFailed(event);
-        }
+        wrappedListener.forkFailed(event);
     }
 
     @Override
     public void mojoSkipped(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.mojoSkipped(event);
-        }
+        wrappedListener.mojoSkipped(event);
     }
 
     @Override
     public void mojoStarted(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.mojoStarted(event);
-        }
+        wrappedListener.mojoStarted(event);
     }
 
     @Override
     public void forkedProjectStarted(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.forkedProjectStarted(event);
-        }
+        wrappedListener.forkedProjectStarted(event);
     }
 
     @Override
     public void forkedProjectSucceeded(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.forkedProjectSucceeded(event);
-        }
+        wrappedListener.forkedProjectSucceeded(event);
     }
 
     @Override
     public void forkedProjectFailed(ExecutionEvent event) {
-        if (wrappedListener != null) {
-            wrappedListener.forkedProjectFailed(event);
-        }
+        wrappedListener.forkedProjectFailed(event);
     }
 }

--- a/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
+++ b/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
@@ -33,7 +33,7 @@ public class BuildInfoRecorderTest extends ArtifactoryMojoTestBase {
     public void setUp() throws Exception {
         super.setUp();
         executionEvent = new TestExecutionEvent(mojo.session, mojo.project);
-        buildInfoRecorder = new BuildInfoRecorder(mojo.session, mojo.getLog(), mojo.artifactory.delegate);
+        buildInfoRecorder = new BuildInfoRecorder(mojo.session, mojo.getLog(), mojo.artifactory.delegate, null);
         mojo.project.setArtifacts(Sets.newHashSet(TEST_ARTIFACT));
     }
 

--- a/src/test/resources/integration/artifactory-maven-plugin-example/pom.xml
+++ b/src/test/resources/integration/artifactory-maven-plugin-example/pom.xml
@@ -55,7 +55,6 @@
                 <groupId>org.jfrog.buildinfo</groupId>
                 <artifactId>artifactory-maven-plugin</artifactId>
                 <version>${artifactory.plugin.version}</version>
-                <inherited>false</inherited>
                 <configuration/>
                 <executions>
                     <execution>

--- a/src/test/resources/integration/maven-archetype-simple/pom.xml
+++ b/src/test/resources/integration/maven-archetype-simple/pom.xml
@@ -34,7 +34,6 @@
                 <groupId>org.jfrog.buildinfo</groupId>
                 <artifactId>artifactory-maven-plugin</artifactId>
                 <version>${artifactory.plugin.version}</version>
-                <inherited>false</inherited>
                 <configuration/>
                 <executions>
                     <execution>


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

This change allows the plugin to be configured in a parent pom and be applied without the need to add the plugin to its build definition.
It also wraps any existing `ExecutionListener` in the `MavenExecutionRequest` so that also get executed. This is especially useful for the `org.apache.maven.cli.event.ExecutionEventLogger`.