### PR TITLE
Bugfix - replaced variables overridden after project started

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
@@ -28,6 +28,7 @@ import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.buildinfo.resolution.RepositoryListener;
 import org.jfrog.buildinfo.types.ModuleArtifacts;
+import org.jfrog.buildinfo.utils.Utils;
 
 import java.io.File;
 import java.util.*;
@@ -71,6 +72,9 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
         ModuleBuilder moduleBuilder = new ModuleBuilder()
                 .id(getModuleIdString(project.getGroupId(), project.getArtifactId(), project.getVersion()))
                 .properties(project.getProperties());
+
+        // Replace variables
+        conf.getAllProperties().replaceAll((key, value) -> Utils.parseInput(value));
 
         // Fill currentModuleArtifacts
         addArtifacts(project);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

Replaced variables replaced by the original value after the Maven project started.
To handle this, I added the replace variables logic in the `projectSucceeded`.