### PR TITLE
Issue 14: Proxy configuration via system properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jfrog.buildinfo</groupId>
     <artifactId>artifactory-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.2.1-forkdvdv2-0</version>
+    <version>3.2.1</version>
     <name>Artifactory Maven plugin</name>
     <url>https://www.jfrog.com/confluence/display/JFROG/Maven+Artifactory+Plugin</url>
     <description>A Maven plugin to resolve artifacts from Artifactory, deploy artifacts to Artifactory, capture and

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jfrog.buildinfo</groupId>
     <artifactId>artifactory-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.2.1</version>
+    <version>3.2.1-forkdvdv2-0</version>
     <name>Artifactory Maven plugin</name>
     <url>https://www.jfrog.com/confluence/display/JFROG/Maven+Artifactory+Plugin</url>
     <description>A Maven plugin to resolve artifacts from Artifactory, deploy artifacts to Artifactory, capture and

--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoClientBuilder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoClientBuilder.java
@@ -37,6 +37,7 @@ public class BuildInfoClientBuilder {
         setTimeout(client);
         setRetriesParams(client);
         setInsecureTls(client);
+        setProxy(client);
         return client;
     }
 
@@ -85,6 +86,16 @@ public class BuildInfoClientBuilder {
         boolean insecureTls = clientConf.getInsecureTls();
         logResolvedProperty(PROP_CONNECTION_RETRIES, String.valueOf(insecureTls));
         client.setInsecureTls(insecureTls);
+    }
+
+    // https://github.com/jfrog/artifactory-maven-plugin/issues/14
+    private void setProxy(ArtifactoryBuildInfoClient client) {
+        final String proxyHost = clientConf.proxy.getHost();
+        if (proxyHost == null) {
+            return;
+        }
+        final int proxyPort = clientConf.proxy.getPort();
+        client.setProxyConfiguration(proxyHost, proxyPort);
     }
 
     private void logResolvedProperty(String key, String value) {


### PR DESCRIPTION
Essentially, the code that allows to set the proxy configuration had been there before (`org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBaseClient#setProxyConfiguration(java.lang.String, int)`. This pull request adds nothing but the ability to access this code by using system properties `artifactory.proxy.host`, `artifactory.proxy.port`
