### PR TITLE
Add missing logger in deploy

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildDeployer.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildDeployer.java
@@ -13,6 +13,7 @@ import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.retention.Utils;
+import org.jfrog.buildinfo.utils.ArtifactoryMavenLogger;
 
 import java.io.IOException;
 import java.util.*;
@@ -49,7 +50,8 @@ public class BuildDeployer {
             return;
         }
 
-        try (ArtifactoryManager client = new ArtifactoryManagerBuilder().setClientConfiguration(clientConf, clientConf.publisher).build()) {
+        try (ArtifactoryManager client = new ArtifactoryManagerBuilder()
+                .setClientConfiguration(clientConf, clientConf.publisher).setLog(new ArtifactoryMavenLogger(logger)).build()) {
             if (clientConf.getInsecureTls()) {
                 client.setInsecureTls(true);
             }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

The `Deploying artifact:...` logging are missing in the master branch.
The root cause of it is using a NullLog defined by the publisher (clientConf.publisher).
Instead, we should use the designated ArtifactoryMavenLogger.