### PR TITLE
populate missing VCS information in the buildInfo

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoModelPropertyResolver.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoModelPropertyResolver.java
@@ -1,5 +1,6 @@
 package org.jfrog.buildinfo.deployment;
 
+import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
@@ -7,6 +8,7 @@ import org.jfrog.build.api.Agent;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.BuildAgent;
 import org.jfrog.build.api.MatrixParameter;
+import org.jfrog.build.api.Vcs;
 import org.jfrog.build.api.builder.BuildInfoMavenBuilder;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 
@@ -62,10 +64,25 @@ public class BuildInfoModelPropertyResolver extends BuildInfoMavenBuilder {
         parentNumber(clientConf.info.getParentBuildNumber());
         parentName(clientConf.info.getParentBuildName());
         vcsRevision(clientConf.info.getVcsRevision());
+        vcsUrl(clientConf.info.getVcsUrl());
+        createVcs(clientConf.info.getVcsUrl(), clientConf.info.getVcsRevision());
         principal(clientConf.info.getPrincipal());
         url(clientConf.info.getBuildUrl());
-    }
+    }       
 
+    /**
+     * Create VCS list when vcsRevision is defined
+     * 
+     * @param vcsUrl      - Url of the VCS
+     * @param vcsRevision - commit revision
+     */
+    private void createVcs(String vcsUrl, String vcsRevision) {
+        if (StringUtils.isNotBlank(vcsRevision)) {
+            Vcs vcsInstance = new Vcs(vcsUrl, vcsRevision);
+            vcs(Arrays.asList(vcsInstance));
+        }        
+    }
+    
     /**
      * Resolve the build agent
      *

--- a/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
+++ b/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
@@ -7,6 +7,7 @@ import org.apache.maven.execution.ExecutionEvent;
 import org.jfrog.build.api.Build;
 import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.Module;
+import org.jfrog.build.api.Vcs;
 import org.jfrog.build.api.builder.BuildInfoBuilder;
 import org.jfrog.buildinfo.deployment.BuildInfoRecorder;
 import org.jfrog.buildinfo.types.TestExecutionEvent;
@@ -52,6 +53,9 @@ public class BuildInfoRecorderTest extends ArtifactoryMojoTestBase {
         assertTrue(build.getStarted().startsWith("2020-01-01T00:00:00.000"));
         assertEquals(0, build.getDurationMillis());
         assertEquals("http://1.2.3.4", build.getUrl());
+        assertEquals(1, build.getVcs().size());
+        Vcs vcs = build.getVcs().get(0);
+        assertEquals("12345", vcs.getRevision());
 
         // Check module
         List<Module> modules = build.getModules();

--- a/src/test/resources/integration/artifactory-maven-plugin-example/pom.xml
+++ b/src/test/resources/integration/artifactory-maven-plugin-example/pom.xml
@@ -84,6 +84,7 @@
                                 <buildName>plugin-demo</buildName>
                                 <buildNumber>${buildnumber}</buildNumber>
                                 <buildUrl>http://build-url.org</buildUrl>
+                                <vcsRevision>123456</vcsRevision>
                             </buildInfo>
                         </configuration>
                     </execution>

--- a/src/test/resources/unit-tests-pom/pom.xml
+++ b/src/test/resources/unit-tests-pom/pom.xml
@@ -56,6 +56,7 @@
                                 <agentName>agentName</agentName>
                                 <agentVersion>2</agentVersion>
                                 <buildRetentionMaxDays>5</buildRetentionMaxDays>
+                                <vcsRevision>12345</vcsRevision>
                             </buildInfo>
                         </configuration>
                     </execution>


### PR DESCRIPTION
I have noticed that for some time now our projects are not uploading VCS revision information to Artifactory. For that I have raised the issue in "Build-Info" project https://github.com/jfrog/build-info/issues/544

However reviewing older version of Maven plugin I have noticed that this information was poplulated in Maven plugin not in the BuildInfo code. 

What this change does it restores the functionality and uploads "vcs" information together with the BuildInfo as described here: https://www.jfrog.com/confluence/display/JFROG/Maven+Artifactory+Plugin

- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. I have modified one test to check for the vcsRevision information
