### PR TITLE
Deploy with maven-deploy-plugin if we skip deployment with artifactory-maven-plugin

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
+++ b/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
@@ -121,7 +121,10 @@ public class ArtifactoryMojo extends AbstractMojo {
      * Skip the default maven deploy behaviour.
      */
     private void skipDefaultDeploy() {
-        session.getUserProperties().put("maven.deploy.skip", Boolean.TRUE.toString());
+        if(publisher.isPublishArtifacts())
+        {
+            session.getUserProperties().put("maven.deploy.skip", Boolean.TRUE.toString());
+        }
     }
 
     /**


### PR DESCRIPTION
Related to: https://github.com/jfrog/artifactory-maven-plugin/issues/38 and also https://github.com/jfrog/artifactory-maven-plugin/issues/32

There are a number of issues with this plugin. 2 of those issues are making me suggest this PR here:
1. The plugin doesn't follow maven conventions for its artifact deployer. It ignores configuration in the distributionManagement section and in the maven settings.xml file and forces the user to manually specify this information again in the artifactory-maven-plugin configuration.
2. Following the updates to maven-install-plugin 3.0.0, artifactory-maven-plugin no longer deploys POM for modules that generate a JAR artifact. It seems to have other problems for example with OSGi bundles. The person who created the issue decided to roll back the maven-install-plugin version. but this is not an acceptable compromise for some workflows.

For this reason, we prefer using the standard maven-deploy-plugin for deploying artifacts to our Artifactory instance. We still want to benefit from the build information collection the plugin does, even if not deploying artifacts with the plugin limits the information collected by the modules section of the build information.

We also think that the artifactory-maven-plugin should allow the user to decide how to deploy artifacts:
- Either with the built-in maven-deploy-plugin
- With the "improved" artifact deployer from the artifactory-maven-plugin
, or
- not at all.

Currently only options 2 and 3 are possible when using the artifactory-maven-plugin, as it always forces a skip on the maven-deploy-plugin if instanciated.

So to the logic to the change is this:
- If publishArtifacts in the publisher configuration is true (as is currently the default), skip the maven-deploy-plugin. This is done to avoid publishing artifacts twice.
- If publishArtifacts in the publisher configuration is false, do not skip the maven-deploy-plugin (and do not use artifactory-maven-plugin). The user can then keep using the maven-deploy-plugin during the deploy phase as usual, or skip that plugin as well using either the skip tag in that plugin's configuration or the maven.deploy.skip property.

- [ ] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.
