### PR TITLE
Support maven.deploy.skip property on a module

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
@@ -2,8 +2,9 @@ package org.jfrog.buildinfo.deployment;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.execution.AbstractExecutionListener;
@@ -14,14 +15,14 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.artifact.ProjectArtifactMetadata;
 import org.apache.maven.repository.legacy.metadata.ArtifactMetadata;
-import org.jfrog.build.extractor.ci.BuildInfo;
-import org.jfrog.build.extractor.ci.Dependency;
-import org.jfrog.build.extractor.builder.ArtifactBuilder;
-import org.jfrog.build.extractor.builder.DependencyBuilder;
-import org.jfrog.build.extractor.builder.ModuleBuilder;
-import org.jfrog.build.extractor.builder.BuildInfoMavenBuilder;
 import org.jfrog.build.extractor.BuildInfoExtractor;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
+import org.jfrog.build.extractor.builder.ArtifactBuilder;
+import org.jfrog.build.extractor.builder.BuildInfoMavenBuilder;
+import org.jfrog.build.extractor.builder.DependencyBuilder;
+import org.jfrog.build.extractor.builder.ModuleBuilder;
+import org.jfrog.build.extractor.ci.BuildInfo;
+import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
@@ -77,7 +78,12 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
         conf.getAllProperties().replaceAll((key, value) -> Utils.parseInput(value));
 
         // Fill currentModuleArtifacts
-        addArtifacts(project);
+        if (BooleanUtils.toBoolean(project.getProperties().getProperty("maven.deploy.skip"))) {
+            logger.info("The artifacts of module '" + project.getArtifactId() +
+                    "' will not be deployed because 'maven.deploy.skip' property is true.");
+        } else {
+            addArtifacts(project);
+        }
 
         // Fill currentModuleDependencies
         addDependencies(project);

--- a/src/test/resources/integration/artifactory-maven-plugin-example/multi3/pom.xml
+++ b/src/test/resources/integration/artifactory-maven-plugin-example/multi3/pom.xml
@@ -10,15 +10,17 @@
     <artifactId>multi3</artifactId>
     <packaging>war</packaging>
     <name>Multi 3</name>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <dependencies>
         <!-- depends on another project (should include transitive) -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>multi1</artifactId>
-           <version>${project.parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
-       
 
         <!-- runtime dependency -->
         <dependency>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

Resolves #39 

Allow skipping deployment of module artifacts using the maven.deploy.skip property:
```xml
<properties>
    <maven.deploy.skip>true</maven.deploy.skip>
</properties>
```