### PR TITLE
Support HTTP proxy

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/Config.java
+++ b/src/main/java/org/jfrog/buildinfo/Config.java
@@ -54,4 +54,12 @@ public class Config {
         @Delegate(types = {ArtifactoryClientConfiguration.BuildInfoHandler.class, PrefixPropertyHandler.class})
         ArtifactoryClientConfiguration.BuildInfoHandler delegate = CLIENT_CONFIGURATION.info;
     }
+
+    /**
+     * Represents the 'proxy' configuration in the pom.xml.
+     */
+    public static class Proxy {
+        @Delegate(types = {ArtifactoryClientConfiguration.ProxyHandler.class, PrefixPropertyHandler.class})
+        ArtifactoryClientConfiguration.ProxyHandler delegate = CLIENT_CONFIGURATION.proxy;
+    }
 }

--- a/src/test/java/org/jfrog/buildinfo/ArtifactoryMojoTest.java
+++ b/src/test/java/org/jfrog/buildinfo/ArtifactoryMojoTest.java
@@ -71,6 +71,16 @@ public class ArtifactoryMojoTest extends ArtifactoryMojoTestBase {
         assertTrue(buildInfo.getBuildStarted().startsWith("2020-01-01T00:00:00.000"));
     }
 
+    public void testProxyConfiguration() {
+        Config.Proxy configProxy = mojo.proxy;
+        assertNotNull(configProxy);
+        ArtifactoryClientConfiguration.ProxyHandler proxyHandler = configProxy.delegate;
+        assertEquals("proxy.jfrog.io", proxyHandler.getHost());
+        assertEquals(Integer.valueOf(8888), proxyHandler.getPort());
+        assertEquals("proxyUser", proxyHandler.getUsername());
+        assertEquals("proxyPassword", proxyHandler.getPassword());
+    }
+
     public void testDeployProperties() {
         // Test input deploy properties
         Map<String, String> deployProperties = mojo.deployProperties;

--- a/src/test/java/org/jfrog/buildinfo/ArtifactoryMojoTestBase.java
+++ b/src/test/java/org/jfrog/buildinfo/ArtifactoryMojoTestBase.java
@@ -137,6 +137,7 @@ public abstract class ArtifactoryMojoTestBase extends AbstractMojoTestCase {
         mojo.buildInfo = objectMapper.readValue(configuration.getChild("buildInfo").toString(), Config.BuildInfo.class);
         mojo.publisher = objectMapper.readValue(configuration.getChild("publisher").toString(), Config.Publisher.class);
         mojo.resolver = objectMapper.readValue(configuration.getChild("resolver").toString(), Config.Resolver.class);
+        mojo.proxy = objectMapper.readValue(configuration.getChild("proxy").toString(), Config.Proxy.class);
         Log log = new MavenLogger();
         mojo.setLog(log);
         mojo.repositoryListener = new RepositoryListener(new PlexusLogger(log));

--- a/src/test/resources/unit-tests-pom/pom.xml
+++ b/src/test/resources/unit-tests-pom/pom.xml
@@ -58,6 +58,12 @@
                                 <agentVersion>2</agentVersion>
                                 <buildRetentionMaxDays>5</buildRetentionMaxDays>
                             </buildInfo>
+                            <proxy>
+                                <host>proxy.jfrog.io</host>
+                                <port>8888</port>
+                                <username>proxyUser</username>
+                                <password>proxyPassword</password>
+                            </proxy>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

Fix #59 

Proxy is already supported before that PR by adding the following system properties to the Maven command:
```
-Dartifactory.proxy.host=acme.jfrog.io 
-Dartifactory.proxy.port=8888 
-Dartifactory.proxy.username=elmar 
-Dartifactory.proxy.password=Wabbit
```

This PR enables configuring HTTP proxy in one of the following new ways:
1. By the regular config:
```xml
<proxy>
    <host>acme.jfrog.io</host>
    <port>8888</port>
    <username>elmar</username>
    <password>Wabbit</password>
</proxy>
```

2. By settings.xml:
```xml
<proxies>
    <proxy>
        <id>jfrog-proxy</id>
        <host>acme.jfrog.io</host>
        <port>8888</port>
        <username>elmar</username>
        <password>Wabbit</password>
    </proxy>
</proxies>
```