### PR TITLE
NullPointerException in v3.6.0 with no proxy config

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
+++ b/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
@@ -91,6 +91,9 @@ public class ArtifactoryMojo extends AbstractMojo {
             return;
         }
         Proxy proxy = session.getSettings().getActiveProxy();
+        if (proxy == null) {
+            return;
+        }
         this.proxy.setHost(proxy.getHost());
         this.proxy.setPort(proxy.getPort());
         this.proxy.setUsername(proxy.getUsername());


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

Fix #66 