### PR TITLE
Make BuildInfoRecorder.java thread safe

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
@@ -223,7 +223,9 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
 
         // if recordAllDependencies=true, add build time dependencies
         if (conf.publisher.isRecordAllDependencies()) {
-            dependencies.addAll(buildTimeDependencies);
+            synchronized(buildTimeDependencies) {
+                dependencies.addAll(buildTimeDependencies);
+            }
         }
 
         currentModuleDependencies.set(dependencies);


### PR DESCRIPTION
The buildTimeDependencies collection is a SynchronizedCollection but like mentioned in the JavaDoc of Collections.synchrizedCollection() it is necessary to use a synchronize block by traversing the collection via iterator, what will be happen by hands over the collection to the addAll method.

- [ ] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.
