### PR TITLE
Avoid test scoped dependencies on build-info when skipTest is enabled

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
+++ b/src/main/java/org/jfrog/buildinfo/ArtifactoryMojo.java
@@ -65,6 +65,9 @@ public class ArtifactoryMojo extends AbstractMojo {
     @Parameter
     Config.Proxy proxy = new Config.Proxy();
 
+    @Parameter(property = "skipTests", defaultValue = "false")
+    boolean skipTests;
+
     @Override
     public void execute() {
         if (session.getRequest().getData().putIfAbsent("configured", Boolean.TRUE) == null) {
@@ -125,7 +128,7 @@ public class ArtifactoryMojo extends AbstractMojo {
         skipDefaultDeploy();
         completeConfig();
         addDeployProperties();
-        BuildInfoRecorder executionListener = new BuildInfoRecorder(session, getLog(), artifactory.delegate);
+        BuildInfoRecorder executionListener = new BuildInfoRecorder(session, getLog(), artifactory.delegate, skipTests);
         repositoryListener.setBuildInfoRecorder(executionListener);
         session.getRequest().setExecutionListener(executionListener);
     }

--- a/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
+++ b/src/main/java/org/jfrog/buildinfo/deployment/BuildInfoRecorder.java
@@ -39,7 +39,6 @@ import java.util.Set;
 
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
-import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.filterBuildInfoProperties;
 import static org.jfrog.buildinfo.utils.Utils.getArtifactName;
 import static org.jfrog.buildinfo.utils.Utils.getDeploymentPath;
 import static org.jfrog.buildinfo.utils.Utils.getFileExtension;
@@ -61,13 +60,15 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
     private final ExecutionListener wrappedListener;
     private final BuildDeployer buildDeployer;
     private final Log logger;
+    private final boolean skipTests;
 
-    public BuildInfoRecorder(MavenSession session, Log logger, ArtifactoryClientConfiguration conf) {
+    public BuildInfoRecorder(MavenSession session, Log logger, ArtifactoryClientConfiguration conf, boolean skipTests) {
         this.wrappedListener = ObjectUtils.defaultIfNull(session.getRequest().getExecutionListener(), new AbstractExecutionListener());
         this.buildInfoBuilder = new BuildInfoModelPropertyResolver(logger, session, conf);
         this.buildDeployer = new BuildDeployer(logger);
         this.logger = logger;
         this.conf = conf;
+        this.skipTests = skipTests;
     }
 
     /**
@@ -95,7 +96,7 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
         }
 
         // Fill currentModuleDependencies
-        addDependencies(project);
+        addDependencies(project, skipTests);
 
         // Build module
         addDependenciesToCurrentModule(moduleBuilder);
@@ -117,7 +118,9 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
      */
     @Override
     public void mojoSucceeded(ExecutionEvent event) {
-        addDependencies(event.getProject());
+
+        addDependencies(event.getProject(), skipTests);
+
 
         wrappedListener.mojoSucceeded(event);
     }
@@ -129,7 +132,7 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
      */
     @Override
     public void mojoFailed(ExecutionEvent event) {
-        addDependencies(event.getProject());
+        addDependencies(event.getProject(), skipTests);
 
         wrappedListener.mojoFailed(event);
     }
@@ -204,14 +207,18 @@ public class BuildInfoRecorder implements BuildInfoExtractor<ExecutionEvent>, Ex
      * In case an artifact is included in both MavenProject dependencies and currentModuleDependencies,
      * we'd like to keep the one that was taken from the MavenProject, because of the scope it has.
      *
-     * @param project - The Maven project
+     * @param project   - The Maven project
+     * @param skipTests
      */
-    private void addDependencies(MavenProject project) {
+    private void addDependencies(MavenProject project, boolean skipTests) {
         // Create a set with new project dependencies. These dependencies are 1st priority in the set.
         Set<Artifact> dependencies = Sets.newHashSet();
         for (Artifact artifact : project.getArtifacts()) {
-            String classifier = StringUtils.defaultString(artifact.getClassifier());
             String scope = StringUtils.defaultIfBlank(artifact.getScope(), Artifact.SCOPE_COMPILE);
+            if (skipTests && Artifact.SCOPE_TEST.equals(scope)) {
+                continue;
+            }
+            String classifier = StringUtils.defaultString(artifact.getClassifier());
             Artifact art = new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(),
                     artifact.getVersion(), scope, artifact.getType(), classifier, artifact.getArtifactHandler());
             art.setFile(artifact.getFile());

--- a/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
+++ b/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
@@ -34,7 +34,7 @@ public class BuildInfoRecorderTest extends ArtifactoryMojoTestBase {
     public void setUp() throws Exception {
         super.setUp();
         executionEvent = new TestExecutionEvent(mojo.session, mojo.project);
-        buildInfoRecorder = new BuildInfoRecorder(mojo.session, mojo.getLog(), mojo.artifactory.delegate);
+        buildInfoRecorder = new BuildInfoRecorder(mojo.session, mojo.getLog(), mojo.artifactory.delegate, true);
         mojo.project.setArtifacts(Sets.newHashSet(TEST_ARTIFACT));
     }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.
