### PR TITLE
Update buildinfo to 2.41.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jfrog.buildinfo</groupId>
     <artifactId>artifactory-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.6.2</version>
+    <version>3.6.3</version>
     <name>Artifactory Maven plugin</name>
     <url>https://www.jfrog.com/confluence/display/JFROG/Maven+Artifactory+Plugin</url>
     <description>A Maven plugin to resolve artifacts from Artifactory, deploy artifacts to Artifactory, capture and
@@ -13,7 +13,7 @@
 
     <properties>
         <maven.min.version>3.3.9</maven.min.version>
-        <buildinfo.version>2.41.3</buildinfo.version>
+        <buildinfo.version>2.41.24</buildinfo.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
https://github.com/jfrog/jenkins-artifactory-plugin/issues/913

Malformed \uxxxx encoding error

- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.
