### PR TITLE
Fix Artifactory Maven Plugin to avoid adding '-mule-plugin' suffix to pom.xml files

### DIFF
--- a/src/main/java/org/jfrog/buildinfo/utils/Utils.java
+++ b/src/main/java/org/jfrog/buildinfo/utils/Utils.java
@@ -110,7 +110,7 @@ public class Utils {
      */
     public static String getArtifactName(String artifactId, String version, String classifier, String fileExtension) {
         String name = artifactId + "-" + version;
-        if (StringUtils.isNotBlank(classifier)) {
+        if (StringUtils.isNotBlank(classifier) && !StringUtils.equals(fileExtension, "pom")) {
             name += "-" + classifier;
         }
         return name + "." + fileExtension;

--- a/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
+++ b/src/test/java/org/jfrog/buildinfo/BuildInfoRecorderTest.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.jfrog.build.api.BuildInfoProperties.BUILD_INFO_ENVIRONMENT_PREFIX;
+import static org.jfrog.buildinfo.utils.Utils.getArtifactName;
 
 /**
  * Test {@link BuildInfoRecorder} class functionality.
@@ -112,6 +113,35 @@ public class BuildInfoRecorderTest extends ArtifactoryMojoTestBase {
         assertEquals(TEST_ARTIFACT.getScope(), dependency.getScope());
         assertEquals(TEST_ARTIFACT.getType(), dependency.getType());
         assertEquals(TEST_ARTIFACT.getClassifier(), dependency.getClassifier());
+    }
+
+    public void testArtifactNameWithoutClassifierForPom() {
+        Artifact pomArtifact = new DefaultArtifact("groupId", "artifactId", "1.0.0", "compile", "pom", "", null);
+        String artifactName = getArtifactName(pomArtifact.getArtifactId(), pomArtifact.getVersion(), pomArtifact.getClassifier(), "pom");
+        assertEquals("artifactId-1.0.0.pom", artifactName);
+    }
+
+    public void testArtifactNameWithClassifierForPom() {
+        Artifact pomArtifact = new DefaultArtifact("groupId", "artifactId", "1.0.0", "compile", "pom", "my-classifier", null);
+        String artifactName = getArtifactName(pomArtifact.getArtifactId(), pomArtifact.getVersion(), pomArtifact.getClassifier(), "pom");
+        assertEquals("artifactId-1.0.0.pom", artifactName); // Ensure suffix is NOT added
+    }
+
+    public void testArtifactNameWithClassifier() {
+        Artifact jarArtifact = new DefaultArtifact("groupId", "artifactId", "1.0.0", "compile", "jar", "my-classifier", null);
+        String artifactName = getArtifactName(jarArtifact.getArtifactId(), jarArtifact.getVersion(), jarArtifact.getClassifier(), jarArtifact.getType());
+        assertEquals("artifactId-1.0.0-my-classifier.jar", artifactName); // Ensure suffix is added
+    }
+
+    public void testGetArtifactNameWithNullFileExtension() {
+        String artifactId = "test-artifact";
+        String version = "1.0.0";
+        String classifier = "my-classifier";
+        String fileExtension = null; // Simulate null file extension
+
+        String artifactName = getArtifactName(artifactId, version, classifier, fileExtension);
+        String expectedName = "test-artifact-1.0.0-my-classifier.null";
+        assertEquals(expectedName, artifactName);
     }
 
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.

---
### Summary
This pull request addresses an issue with the Artifactory Maven Plugin where the deployed `pom.xml` files inadvertently included a `-mule-plugin` suffix. This change ensures that the artifact naming follows Maven conventions and allows clients to resolve dependencies successfully.

### Problem
When using the Artifactory Maven Plugin in conjunction with the Mule plugin, the `pom.xml` files are deployed to the Artifactory local repository with an erroneous suffix. For example, instead of `dummy-project-1.0.0-20241113.201822-3.pom`, the file name appears as `dummy-project-1.0.0-20241113.201822-3-mule-plugin.pom`. This issue leads to failures when Maven clients or Jenkins builds attempt to resolve these artifacts since they can't find the expected POM file names.

**Related Issue:** [#90 - Artifactory Maven Plugin adding '-mule-plugin' suffix to POM files](https://github.com/jfrog/artifactory-maven-plugin/issues/90)

### Changes Made
- Modified the artifact naming logic in the Artifactory Maven Plugin:
  - Adjusted the `getArtifactName()` method to prevent the `-mule-plugin` suffix from being added to `pom.xml` files.
  - Ensured that the suffix is only appended for non-POM artifacts.

### Testing
- Added unit tests to verify the artifact naming behavior now correctly handles:
  - `pom` files without classifiers
  - `pom` files with classifiers
  - Non-POM artifacts with classifiers

All tests pass successfully, confirming that the changes are functional and do not introduce any regressions.

### Impact
This fix improves compatibility with standard Maven workflows and ensures that teams utilizing both the Artifactory Maven Plugin and Mule plugin can deploy and resolve their artifacts without encountering issues related to artifact naming.
