### PR TITLE
fix: resolve integration test infrastructure issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,16 +75,6 @@
                 <version>3.4.2</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.18.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.18.2</version>
-            </dependency>
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
                 <version>4.1.125.Final</version>
@@ -180,6 +170,23 @@
             <groupId>org.jfrog.filespecs</groupId>
             <artifactId>file-specs-java</artifactId>
             <version>1.1.2</version>
+        </dependency>
+
+        <!--Jackson - Override transitive dependencies with secure versions-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.18.2</version>
         </dependency>
 
         <!--Apache Commons-->
@@ -291,13 +298,9 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.15.0</version>
+            <version>5.14.0</version>
             <scope>test</scope>
             <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-text</artifactId>
@@ -325,7 +328,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.
---
**Title:** Fix MockServer integration test failures caused by Jackson version conflict
## Description:
### Problem:
After the security upgrades in PR #112, integration tests started failing with:
```
IllegalArgumentException: exception while parsing [...] for Expectation
```
**Root Cause:**
The dependencyManagement section was forcing Jackson 2.18.2 on all dependencies, including MockServer's transitive dependencies. MockServer 5.14.0/5.15.0 is incompatible with Jackson 2.18.2, causing JSON parsing failures.
**Solution:**
- Removed jackson-databind and jackson-core from <dependencyManagement> to prevent version forcing on test dependencies
- Added Jackson 2.18.2 as explicit compile-scope dependencies to maintain security fixes for production code
- Reverted MockServer to 5.14.0 and removed the unnecessary jackson-databind exclusion
