### PR TITLE
Fix Security Violation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <maven.min.version>3.8.1</maven.min.version>
-        <buildinfo.version>2.43.4</buildinfo.version>
+        <buildinfo.version>2.43.6</buildinfo.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -77,27 +77,27 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.129.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -176,17 +176,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.6</version>
         </dependency>
 
         <!--Apache Commons-->
@@ -268,7 +268,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -286,13 +286,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-maven-plugin#testing-the-plugin) passed. If this feature is not already covered by the tests, I added new tests.
---
**Title:** Fix security audit violations - upgrade jackson, netty, plexus-archiver, build-info

**Description:**
Upgrade vulnerable direct dependencies to resolve `jf audit` security violations.

- jackson (core/databind/annotations/dataformat-xml/datatype-guava): 2.18.2 → 2.18.6
- netty (all modules): 4.1.125.Final → 4.1.130.Final
- plexus-archiver: 4.10.0 → 4.10.3 (fixes CVE-2025-67721)
- build-info-extractor: 2.43.4 → 2.43.6